### PR TITLE
Load user's calorie goal and correct macro slider behavior

### DIFF
--- a/src/app/plan/page.js
+++ b/src/app/plan/page.js
@@ -1,7 +1,7 @@
 "use client";
 import { useState, useEffect } from "react";
 import { db } from "@/lib/firebase";
-import { collection, getDocs } from "firebase/firestore";
+import { collection, getDocs, doc, getDoc } from "firebase/firestore";
 import { DndContext, closestCenter, DragOverlay } from "@dnd-kit/core";
 import Sidebar from "@/components/Sidebar";
 import SingleDayPlan from "@/components/SingleDayPlan";
@@ -30,9 +30,15 @@ export default function SingleDayMealPlanPage() {
   const [dragItem, setDragItem] = useState(null);
 
   useEffect(() => {
-    if (user && user.dailyGoal) {
-      setCalorieGoal(user.dailyGoal);
-    }
+    const fetchGoal = async () => {
+      if (!user) return;
+      const docRef = doc(db, "users", user.uid);
+      const snap = await getDoc(docRef);
+      if (snap.exists() && snap.data().dailyGoal) {
+        setCalorieGoal(snap.data().dailyGoal);
+      }
+    };
+    fetchGoal();
   }, [user]);
 
   useEffect(() => {

--- a/src/app/plan/page.js
+++ b/src/app/plan/page.js
@@ -93,37 +93,41 @@ export default function SingleDayMealPlanPage() {
   };
 
   return (
-    <div className="flex flex-col md:flex-row min-h-screen">
-      <MacroGoalControl
-        calorieGoal={calorieGoal}
-        // setCalorieGoal={setCalorieGoal}
-        macroPercents={macroPercents}
-        setMacroPercents={setMacroPercents}
-      />
+    <div className="flex flex-col min-h-screen">
+      <div className="p-4">
+        <MacroGoalControl
+          calorieGoal={calorieGoal}
+          // setCalorieGoal={setCalorieGoal}
+          macroPercents={macroPercents}
+          setMacroPercents={setMacroPercents}
+        />
+      </div>
       <DndContext
         collisionDetection={closestCenter}
         onDragEnd={handleDragEnd}
         onDragStart={handleDragStart}
       >
-        <main className="flex-1 p-4 overflow-auto">
-          <h1 className="text-2xl font-bold mb-4">Single Day Meal Plan</h1>
-          <SingleDayPlan meals={meals} onRemoveItem={handleRemoveItem} />
-          <DragOverlay>
-            {dragItem && (
-              <div className="p-2 bg-white rounded shadow border-2 border-blue-500 opacity-90 text-xs inline-flex flex-col items-start">
-                <div className="flex items-center gap-x-1 whitespace-nowrap">
-                  <span>{dragItem.name}</span>
-                  {dragItem.type === "recipe" && (
-                    <span className="text-[9px] text-blue-600 bg-blue-50 rounded px-1 py-[1px]">
-                      [Recipe]
-                    </span>
-                  )}
+        <div className="flex flex-1 flex-col md:flex-row">
+          <main className="flex-1 p-4 overflow-auto">
+            <h1 className="text-2xl font-bold mb-4">Single Day Meal Plan</h1>
+            <SingleDayPlan meals={meals} onRemoveItem={handleRemoveItem} />
+            <DragOverlay>
+              {dragItem && (
+                <div className="p-2 bg-white rounded shadow border-2 border-blue-500 opacity-90 text-xs inline-flex flex-col items-start">
+                  <div className="flex items-center gap-x-1 whitespace-nowrap">
+                    <span>{dragItem.name}</span>
+                    {dragItem.type === "recipe" && (
+                      <span className="text-[9px] text-blue-600 bg-blue-50 rounded px-1 py-[1px]">
+                        [Recipe]
+                      </span>
+                    )}
+                  </div>
                 </div>
-              </div>
-            )}
-          </DragOverlay>
-        </main>
-        <Sidebar ingredients={ingredients} recipes={recipes} />
+              )}
+            </DragOverlay>
+          </main>
+          <Sidebar ingredients={ingredients} recipes={recipes} />
+        </div>
       </DndContext>
     </div>
   );

--- a/src/components/MacroGoalControl.js
+++ b/src/components/MacroGoalControl.js
@@ -10,25 +10,17 @@ export default function MacroGoalControl({
 }) {
   // Handler for sliders
   const handleChange = (macro, value) => {
-    value = Math.max(0, Math.min(100, Number(value)));
-    let other = macro === "protein" ? "fat" : "protein";
+    value = Number(value);
+    const other = macro === "protein" ? "fat" : "protein";
     setMacroPercents((prev) => {
-      let carbs = 100 - value - prev[other];
-      if (carbs < 0) {
-        let over = Math.abs(carbs);
-        let newOther = Math.max(0, prev[other] - over);
-        carbs = 100 - value - newOther;
-        return {
-          ...prev,
-          [macro]: value,
-          [other]: newOther,
-          carbs,
-        };
-      }
+      // clamp so carbs never drop below zero
+      const clamped = Math.max(0, Math.min(100 - prev[other], value));
       return {
         ...prev,
-        [macro]: value,
-        carbs,
+        [macro]: clamped,
+        carbs:
+          100 - (macro === "protein" ? clamped : prev.protein) -
+          (macro === "fat" ? clamped : prev.fat),
       };
     });
   };

--- a/src/components/MacroGoalControl.js
+++ b/src/components/MacroGoalControl.js
@@ -1,6 +1,5 @@
 "use client";
 
-
 export default function MacroGoalControl({
   calorieGoal,
   // setCalorieGoal,
@@ -19,7 +18,8 @@ export default function MacroGoalControl({
         ...prev,
         [macro]: clamped,
         carbs:
-          100 - (macro === "protein" ? clamped : prev.protein) -
+          100 -
+          (macro === "protein" ? clamped : prev.protein) -
           (macro === "fat" ? clamped : prev.fat),
       };
     });
@@ -67,7 +67,7 @@ export default function MacroGoalControl({
           <input
             type="range"
             min={0}
-            max={100 - macroPercents.fat}
+            max={100}
             value={macroPercents.protein}
             onChange={(e) => handleChange("protein", e.target.value)}
             className="w-full accent-blue-700"
@@ -85,7 +85,7 @@ export default function MacroGoalControl({
           <input
             type="range"
             min={0}
-            max={100 - macroPercents.protein}
+            max={100}
             value={macroPercents.fat}
             onChange={(e) => handleChange("fat", e.target.value)}
             className="w-full accent-orange-700"

--- a/src/components/MacroGoalControl.js
+++ b/src/components/MacroGoalControl.js
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect } from "react";
+
 
 export default function MacroGoalControl({
   calorieGoal,
@@ -12,25 +12,25 @@ export default function MacroGoalControl({
   const handleChange = (macro, value) => {
     value = Math.max(0, Math.min(100, Number(value)));
     let other = macro === "protein" ? "fat" : "protein";
-    let carbs = 100 - value - macroPercents[other];
-    if (carbs < 0) {
-      // Reduce other macro if needed
-      let over = Math.abs(carbs);
-      let newOther = Math.max(0, macroPercents[other] - over);
-      carbs = 100 - value - newOther;
-      setMacroPercents({
-        ...macroPercents,
+    setMacroPercents((prev) => {
+      let carbs = 100 - value - prev[other];
+      if (carbs < 0) {
+        let over = Math.abs(carbs);
+        let newOther = Math.max(0, prev[other] - over);
+        carbs = 100 - value - newOther;
+        return {
+          ...prev,
+          [macro]: value,
+          [other]: newOther,
+          carbs,
+        };
+      }
+      return {
+        ...prev,
         [macro]: value,
-        [other]: newOther,
         carbs,
-      });
-    } else {
-      setMacroPercents({
-        ...macroPercents,
-        [macro]: value,
-        carbs,
-      });
-    }
+      };
+    });
   };
 
   // When user info updates, update calorieGoal (if desired)

--- a/src/components/MacroGoalControl.js
+++ b/src/components/MacroGoalControl.js
@@ -1,11 +1,16 @@
 "use client";
-
+const MACRO_RANGES = {
+  protein: { min: 20, max: 35 },
+  fat: { min: 20, max: 35 },
+  carbs: { min: 35, max: 60 }, // not used for slider, but for info
+};
+function isWithin(val, { min, max }) {
+  return val >= min && val <= max;
+}
 export default function MacroGoalControl({
   calorieGoal,
-  // setCalorieGoal,
   macroPercents,
   setMacroPercents,
-  // userCalorieTarget,
 }) {
   // Handler for sliders
   const handleChange = (macro, value) => {
@@ -25,27 +30,12 @@ export default function MacroGoalControl({
     });
   };
 
-  // When user info updates, update calorieGoal (if desired)
-  // useEffect(() => {
-  //   if (userCalorieTarget && !calorieGoal) setCalorieGoal(userCalorieTarget);
-  // }, [userCalorieTarget, calorieGoal, setCalorieGoal]);
-
   return (
     <div className="mb-4 p-4 bg-white rounded shadow max-w-2xl mx-auto flex flex-col gap-3">
       <div className="flex items-end gap-2 mb-2">
         <label className="text-sm font-semibold">Daily Calorie Target:</label>
         <span className="ml-2 font-mono">{calorieGoal ?? "—"}</span>
         <span className="text-gray-600 ml-1 text-sm">kcal</span>
-        {/* {setCalorieGoal && (
-          <input
-            type="number"
-            className="border p-1 rounded w-20 ml-4"
-            value={calorieGoal}
-            onChange={(e) => setCalorieGoal(Number(e.target.value))}
-            min={0}
-            step={1}
-          />
-        )} */}
       </div>
       <div className="flex gap-6 items-center">
         <div className="flex flex-col gap-4 items-end text-right min-w-[58px]">


### PR DESCRIPTION
## Summary
- fetch daily calorie goal from Firestore when planning a meal
- ensure macro sliders always total 100% using functional state updates

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684ef3b22a58832b9fab61cdc72ccd95