### PR TITLE
Enhance daily meal plan UI with totals

### DIFF
--- a/src/app/plan/page.js
+++ b/src/app/plan/page.js
@@ -110,7 +110,12 @@ export default function SingleDayMealPlanPage() {
         <div className="flex flex-1 flex-col md:flex-row">
           <main className="flex-1 p-4 overflow-auto">
             <h1 className="text-2xl font-bold mb-4">Single Day Meal Plan</h1>
-            <SingleDayPlan meals={meals} onRemoveItem={handleRemoveItem} />
+            <SingleDayPlan
+              meals={meals}
+              onRemoveItem={handleRemoveItem}
+              calorieGoal={calorieGoal}
+              macroPercents={macroPercents}
+            />
             <DragOverlay>
               {dragItem && (
                 <div className="p-2 bg-white rounded shadow border-2 border-blue-500 opacity-90 text-xs inline-flex flex-col items-start">

--- a/src/app/plan/page.js
+++ b/src/app/plan/page.js
@@ -99,7 +99,7 @@ export default function SingleDayMealPlanPage() {
       onDragStart={handleDragStart}
     >
       <div className="grid min-h-screen grid-cols-1 md:grid-cols-[1fr_340px]">
-        <main className="p-4 overflow-auto">
+        <main className="p-4 overflow-auto flex flex-col items-center">
           <div className="mb-4">
             <MacroGoalControl
               calorieGoal={calorieGoal}
@@ -108,7 +108,7 @@ export default function SingleDayMealPlanPage() {
               setMacroPercents={setMacroPercents}
             />
           </div>
-          <h1 className="text-2xl font-bold mb-4">Single Day Meal Plan</h1>
+          <h1 className="text-2xl font-bold mb-4 text-center">Single Day Meal Plan</h1>
           <SingleDayPlan
             meals={meals}
             onRemoveItem={handleRemoveItem}

--- a/src/app/plan/page.js
+++ b/src/app/plan/page.js
@@ -93,47 +93,45 @@ export default function SingleDayMealPlanPage() {
   };
 
   return (
-    <div className="flex flex-col min-h-screen">
-      <div className="p-4">
-        <MacroGoalControl
-          calorieGoal={calorieGoal}
-          // setCalorieGoal={setCalorieGoal}
-          macroPercents={macroPercents}
-          setMacroPercents={setMacroPercents}
-        />
-      </div>
-      <DndContext
-        collisionDetection={closestCenter}
-        onDragEnd={handleDragEnd}
-        onDragStart={handleDragStart}
-      >
-        <div className="flex flex-1 flex-col md:flex-row">
-          <main className="flex-1 p-4 overflow-auto">
-            <h1 className="text-2xl font-bold mb-4">Single Day Meal Plan</h1>
-            <SingleDayPlan
-              meals={meals}
-              onRemoveItem={handleRemoveItem}
+    <DndContext
+      collisionDetection={closestCenter}
+      onDragEnd={handleDragEnd}
+      onDragStart={handleDragStart}
+    >
+      <div className="grid min-h-screen grid-cols-1 md:grid-cols-[1fr_340px]">
+        <main className="p-4 overflow-auto">
+          <div className="mb-4">
+            <MacroGoalControl
               calorieGoal={calorieGoal}
+              // setCalorieGoal={setCalorieGoal}
               macroPercents={macroPercents}
+              setMacroPercents={setMacroPercents}
             />
-            <DragOverlay>
-              {dragItem && (
-                <div className="p-2 bg-white rounded shadow border-2 border-blue-500 opacity-90 text-xs inline-flex flex-col items-start">
-                  <div className="flex items-center gap-x-1 whitespace-nowrap">
-                    <span>{dragItem.name}</span>
-                    {dragItem.type === "recipe" && (
-                      <span className="text-[9px] text-blue-600 bg-blue-50 rounded px-1 py-[1px]">
-                        [Recipe]
-                      </span>
-                    )}
-                  </div>
+          </div>
+          <h1 className="text-2xl font-bold mb-4">Single Day Meal Plan</h1>
+          <SingleDayPlan
+            meals={meals}
+            onRemoveItem={handleRemoveItem}
+            calorieGoal={calorieGoal}
+            macroPercents={macroPercents}
+          />
+          <DragOverlay>
+            {dragItem && (
+              <div className="p-2 bg-white rounded shadow border-2 border-blue-500 opacity-90 text-xs inline-flex flex-col items-start">
+                <div className="flex items-center gap-x-1 whitespace-nowrap">
+                  <span>{dragItem.name}</span>
+                  {dragItem.type === "recipe" && (
+                    <span className="text-[9px] text-blue-600 bg-blue-50 rounded px-1 py-[1px]">
+                      [Recipe]
+                    </span>
+                  )}
                 </div>
-              )}
-            </DragOverlay>
-          </main>
-          <Sidebar ingredients={ingredients} recipes={recipes} />
-        </div>
-      </DndContext>
-    </div>
+              </div>
+            )}
+          </DragOverlay>
+        </main>
+        <Sidebar ingredients={ingredients} recipes={recipes} />
+      </div>
+    </DndContext>
   );
 }

--- a/src/components/MacroGoalControl.js
+++ b/src/components/MacroGoalControl.js
@@ -31,7 +31,7 @@ export default function MacroGoalControl({
   };
 
   return (
-    <div className="mb-4 p-4 bg-white rounded shadow max-w-2xl mx-auto flex flex-col gap-3">
+    <div className="mb-2 p-2 bg-white rounded shadow max-w-xl mx-auto flex flex-col gap-2 text-sm">
       <div className="flex items-end gap-2 mb-2">
         <label className="text-sm font-semibold">Daily Calorie Target:</label>
         <span className="ml-2 font-mono">{calorieGoal ?? "—"}</span>

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -3,7 +3,7 @@ import SidebarItem from "./SidebarItem";
 
 export default function Sidebar({ ingredients, recipes }) {
   return (
-    <aside className="md:w-[340px] w-full md:border-l border-t md:border-t-0 flex flex-col sticky top-0 right-0 max-h-screen h-screen bg-gray-50 z-10">
+    <aside className="md:w-[340px] w-full md:border-l border-t md:border-t-0 flex flex-col sticky top-0 right-0 h-screen bg-gray-50 z-10">
       <div className="flex flex-col h-full">
         <div className="overflow-y-auto border-b p-2" style={{ height: "33%" }}>
           <h2 className="font-bold mb-2 text-xs">Recipes</h2>

--- a/src/components/SingleDayPlan.js
+++ b/src/components/SingleDayPlan.js
@@ -26,7 +26,7 @@ function getItemMacros(item) {
   return { kcal: 0, p: 0, c: 0, f: 0 };
 }
 
-export default function SingleDayPlan({ meals, onRemoveItem }) {
+export default function SingleDayPlan({ meals, onRemoveItem, calorieGoal = 0, macroPercents }) {
   // meals: { Breakfast: [], Lunch: [], Dinner: [] }
 
   // Macro sum for each meal
@@ -42,6 +42,34 @@ export default function SingleDayPlan({ meals, onRemoveItem }) {
     });
     macroSums[meal] = sum;
   });
+
+  const dailyTotal = MEALS.reduce(
+    (acc, m) => {
+      const sum = macroSums[m] || { kcal: 0, p: 0, c: 0, f: 0 };
+      acc.kcal += sum.kcal;
+      acc.p += sum.p;
+      acc.c += sum.c;
+      acc.f += sum.f;
+      return acc;
+    },
+    { kcal: 0, p: 0, c: 0, f: 0 }
+  );
+
+  const targetMacros = calorieGoal
+    ? {
+        kcal: calorieGoal,
+        p: Math.round((calorieGoal * (macroPercents?.protein || 0)) / 400),
+        c: Math.round((calorieGoal * (macroPercents?.carbs || 0)) / 400),
+        f: Math.round((calorieGoal * (macroPercents?.fat || 0)) / 900),
+      }
+    : null;
+
+  const diffIndicator = (actual, target) => {
+    if (!target) return null;
+    if (actual > target) return <span className="text-red-600">↑</span>;
+    if (actual < target) return <span className="text-blue-600">↓</span>;
+    return null;
+  };
 
   return (
     <div>
@@ -66,27 +94,37 @@ export default function SingleDayPlan({ meals, onRemoveItem }) {
               />
             ))}
           </tr>
+          <tr className="bg-gray-50 text-[13px]">
+            {MEALS.map((meal) => (
+              <td key={meal} className="border p-2 text-center">
+                <div>
+                  <span className="font-semibold">{macroSums[meal].kcal}</span> kcal
+                </div>
+                <div>
+                  <span className="text-blue-700">{macroSums[meal].p}p</span> /{' '}
+                  <span className="text-green-700">{macroSums[meal].c}c</span> /{' '}
+                  <span className="text-orange-700">{macroSums[meal].f}f</span>
+                </div>
+              </td>
+            ))}
+          </tr>
+          <tr className="bg-gray-100">
+            <td colSpan={MEALS.length} className="border p-2 text-center text-sm">
+              <div className="font-semibold mb-1">Daily Total</div>
+              <div>
+                <span className="font-mono">{dailyTotal.kcal}</span> kcal
+                {diffIndicator(dailyTotal.kcal, targetMacros?.kcal)} {' / '}
+                <span className="font-mono text-blue-700">{dailyTotal.p}p</span>
+                {diffIndicator(dailyTotal.p, targetMacros?.p)} {' / '}
+                <span className="font-mono text-green-700">{dailyTotal.c}c</span>
+                {diffIndicator(dailyTotal.c, targetMacros?.c)} {' / '}
+                <span className="font-mono text-orange-700">{dailyTotal.f}f</span>
+                {diffIndicator(dailyTotal.f, targetMacros?.f)}
+              </div>
+            </td>
+          </tr>
         </tbody>
       </table>
-      {/* Macros summary row */}
-      <div className="flex gap-2 justify-around mt-4 w-full max-w-2xl mx-auto">
-        {MEALS.map((meal) => (
-          <div
-            key={meal}
-            className="flex flex-col items-center bg-gray-50 p-2 rounded shadow text-[13px] min-w-[110px]"
-          >
-            <div className="font-semibold mb-1">{meal}</div>
-            <div>
-              <span className="font-bold">{macroSums[meal].kcal}</span> kcal
-            </div>
-            <div>
-              <span className="text-blue-700">{macroSums[meal].p}p</span> /{" "}
-              <span className="text-green-700">{macroSums[meal].c}c</span> /{" "}
-              <span className="text-orange-700">{macroSums[meal].f}f</span>
-            </div>
-          </div>
-        ))}
-      </div>
     </div>
   );
 }

--- a/src/components/SingleDayPlan.js
+++ b/src/components/SingleDayPlan.js
@@ -73,7 +73,7 @@ export default function SingleDayPlan({ meals, onRemoveItem, calorieGoal = 0, ma
 
   return (
     <div>
-      <table className="min-w-[400px] max-w-2xl w-full border text-xs md:text-base mb-4">
+      <table className="min-w-[400px] max-w-2xl w-full border text-xs md:text-base mb-4 mx-auto">
         <thead>
           <tr>
             {MEALS.map((meal) => (


### PR DESCRIPTION
## Summary
- tweak sidebar height styling
- reduce padding/size of macro goal controls
- add daily total row and target indicators in SingleDayPlan
- pass calorie goal and macro percents down to SingleDayPlan

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f1919824c832ba81123f0756ead0d