### PR TITLE
Add grams prompt for dropped ingredients

### DIFF
--- a/src/app/plan/page.js
+++ b/src/app/plan/page.js
@@ -81,15 +81,28 @@ export default function SingleDayMealPlanPage() {
     setDragItem(null);
     if (!event.over) return;
     const meal = event.over.id.replace("SingleDay-", "");
+    const data = event.active.data.current;
     setMeals((prev) => {
       const updated = { ...prev };
       const already = updated[meal].find(
-        (i) =>
-          i.id === event.active.data.current.id &&
-          i.type === event.active.data.current.type
+        (i) => i.id === data.id && i.type === data.type
       );
       if (already) return prev;
-      updated[meal] = [...updated[meal], event.active.data.current];
+
+      let newItem = { ...data };
+      if (newItem.type === "ingredient") {
+        const gramsInput = window.prompt(
+          `How many grams of ${newItem.name}?`,
+          newItem.servingSize || ""
+        );
+        if (gramsInput === null) return prev;
+        const grams = parseFloat(gramsInput);
+        if (!isNaN(grams)) {
+          newItem.grams = grams;
+        }
+      }
+
+      updated[meal] = [...updated[meal], newItem];
       return updated;
     });
   };

--- a/src/components/MealItemCard.js
+++ b/src/components/MealItemCard.js
@@ -1,13 +1,13 @@
 "use client";
 function getIngredientNutrition(item) {
-  return item.caloriesPerServing !== undefined
-    ? {
-        kcal: item.caloriesPerServing,
-        p: item.proteinPerServing,
-        c: item.carbsPerServing,
-        f: item.fatPerServing,
-      }
-    : null;
+  if (item.caloriesPerServing === undefined) return null;
+  const factor = item.grams ? item.grams / (item.servingSize || 1) : 1;
+  return {
+    kcal: (item.caloriesPerServing || 0) * factor,
+    p: (item.proteinPerServing || 0) * factor,
+    c: (item.carbsPerServing || 0) * factor,
+    f: (item.fatPerServing || 0) * factor,
+  };
 }
 function getRecipeNutrition(item) {
   return item.macrosPerServing
@@ -46,6 +46,9 @@ export default function MealItemCard({ item, onRemove }) {
     >
       <div className="flex items-center gap-x-1 whitespace-nowrap">
         <span>{item.name}</span>
+        {item.grams !== undefined && (
+          <span className="text-[9px] text-gray-600">({item.grams}g)</span>
+        )}
         {item.type === "recipe" && (
           <span className="text-[9px] text-blue-600 bg-blue-50 rounded px-1 py-[1px]">
             [Recipe]
@@ -54,8 +57,8 @@ export default function MealItemCard({ item, onRemove }) {
       </div>
       {nutrition && (
         <span className="text-[10px] text-gray-500 mt-[1px] whitespace-nowrap">
-          {nutrition.kcal} kcal / {nutrition.p}p / {nutrition.c}c /{" "}
-          {nutrition.f}f
+          {nutrition.kcal.toFixed ? nutrition.kcal.toFixed(0) : nutrition.kcal} kcal / {nutrition.p.toFixed ? nutrition.p.toFixed(1) : nutrition.p}p / {nutrition.c.toFixed ? nutrition.c.toFixed(1) : nutrition.c}c /{' '}
+          {nutrition.f.toFixed ? nutrition.f.toFixed(1) : nutrition.f}f
         </span>
       )}
       <button

--- a/src/components/SingleDayPlan.js
+++ b/src/components/SingleDayPlan.js
@@ -5,11 +5,14 @@ const MEALS = ["Breakfast", "Lunch", "Dinner"];
 
 function getItemMacros(item) {
   if (item.type === "ingredient" && item.caloriesPerServing !== undefined) {
+    const factor = item.grams
+      ? item.grams / (item.servingSize || 1)
+      : 1;
     return {
-      kcal: item.caloriesPerServing,
-      p: item.proteinPerServing,
-      c: item.carbsPerServing,
-      f: item.fatPerServing,
+      kcal: (item.caloriesPerServing || 0) * factor,
+      p: (item.proteinPerServing || 0) * factor,
+      c: (item.carbsPerServing || 0) * factor,
+      f: (item.fatPerServing || 0) * factor,
     };
   }
   if (item.type === "recipe" && item.macrosPerServing) {
@@ -98,12 +101,12 @@ export default function SingleDayPlan({ meals, onRemoveItem, calorieGoal = 0, ma
             {MEALS.map((meal) => (
               <td key={meal} className="border p-2 text-center">
                 <div>
-                  <span className="font-semibold">{macroSums[meal].kcal}</span> kcal
+                  <span className="font-semibold">{macroSums[meal].kcal.toFixed(0)}</span> kcal
                 </div>
                 <div>
-                  <span className="text-blue-700">{macroSums[meal].p}p</span> /{' '}
-                  <span className="text-green-700">{macroSums[meal].c}c</span> /{' '}
-                  <span className="text-orange-700">{macroSums[meal].f}f</span>
+                  <span className="text-blue-700">{macroSums[meal].p.toFixed(1)}p</span> /{' '}
+                  <span className="text-green-700">{macroSums[meal].c.toFixed(1)}c</span> /{' '}
+                  <span className="text-orange-700">{macroSums[meal].f.toFixed(1)}f</span>
                 </div>
               </td>
             ))}
@@ -112,13 +115,13 @@ export default function SingleDayPlan({ meals, onRemoveItem, calorieGoal = 0, ma
             <td colSpan={MEALS.length} className="border p-2 text-center text-sm">
               <div className="font-semibold mb-1">Daily Total</div>
               <div>
-                <span className="font-mono">{dailyTotal.kcal}</span> kcal
+                <span className="font-mono">{dailyTotal.kcal.toFixed(0)}</span> kcal
                 {diffIndicator(dailyTotal.kcal, targetMacros?.kcal)} {' / '}
-                <span className="font-mono text-blue-700">{dailyTotal.p}p</span>
+                <span className="font-mono text-blue-700">{dailyTotal.p.toFixed(1)}p</span>
                 {diffIndicator(dailyTotal.p, targetMacros?.p)} {' / '}
-                <span className="font-mono text-green-700">{dailyTotal.c}c</span>
+                <span className="font-mono text-green-700">{dailyTotal.c.toFixed(1)}c</span>
                 {diffIndicator(dailyTotal.c, targetMacros?.c)} {' / '}
-                <span className="font-mono text-orange-700">{dailyTotal.f}f</span>
+                <span className="font-mono text-orange-700">{dailyTotal.f.toFixed(1)}f</span>
                 {diffIndicator(dailyTotal.f, targetMacros?.f)}
               </div>
             </td>
@@ -136,10 +139,10 @@ export default function SingleDayPlan({ meals, onRemoveItem, calorieGoal = 0, ma
           </div>
           <div>
             <span className="font-semibold">Actual:</span>{' '}
-            <span className="font-mono">{dailyTotal.kcal}</span> kcal /{' '}
-            <span className="text-blue-700">{dailyTotal.p}p</span> /{' '}
-            <span className="text-green-700">{dailyTotal.c}c</span> /{' '}
-            <span className="text-orange-700">{dailyTotal.f}f</span>
+            <span className="font-mono">{dailyTotal.kcal.toFixed(0)}</span> kcal /{' '}
+            <span className="text-blue-700">{dailyTotal.p.toFixed(1)}p</span> /{' '}
+            <span className="text-green-700">{dailyTotal.c.toFixed(1)}c</span> /{' '}
+            <span className="text-orange-700">{dailyTotal.f.toFixed(1)}f</span>
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary
- prompt for grams of ingredient when dropped on a meal
- compute macros by grams for meal items
- display selected grams in meal cards
- show rounded macro values in the daily plan

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f57ca8d14832b9c603191114339fe