### PR TITLE
Add named meal plans and store macro goals

### DIFF
--- a/src/app/HeaderBar.js
+++ b/src/app/HeaderBar.js
@@ -17,7 +17,7 @@ export default function HeaderBar() {
             />
           </svg> */}
           <span className="font-extrabold text-lg text-gray-900 tracking-tight font-heading">
-            MealPrep
+            Prep Thy Mealz
           </span>
         </div>
         <nav className="hidden md:flex items-center gap-7">

--- a/src/app/plan/page.js
+++ b/src/app/plan/page.js
@@ -191,15 +191,16 @@ export default function SingleDayMealPlanPage() {
     >
       <div className="grid min-h-screen grid-cols-1 md:grid-cols-[1fr_340px]">
         <main className="p-4 overflow-auto flex flex-col items-center">
-          <div className="mb-4">
-            <MacroGoalControl
-              calorieGoal={calorieGoal}
-              // setCalorieGoal={setCalorieGoal}
-              macroPercents={macroPercents}
-              setMacroPercents={setMacroPercents}
-            />
-          </div>
-          <div className="mb-4 flex flex-col items-center gap-2 w-full max-w-md">
+          <div className="w-full max-w-2xl">
+            <div className="mb-4">
+              <MacroGoalControl
+                calorieGoal={calorieGoal}
+                // setCalorieGoal={setCalorieGoal}
+                macroPercents={macroPercents}
+                setMacroPercents={setMacroPercents}
+              />
+            </div>
+            <div className="mb-4 flex flex-col items-center gap-2 w-full max-w-md">
             <input
               className="border px-2 py-1 w-full"
               placeholder="Plan Name"
@@ -207,7 +208,7 @@ export default function SingleDayMealPlanPage() {
               onChange={(e) => setPlanName(e.target.value)}
             />
             {planList.length > 0 && (
-              <div className="flex items-center gap-2 w-full">
+              <div className="flex flex-wrap items-center gap-2 w-full">
                 <select
                   className="border px-2 py-1 flex-1"
                   value={selectedPlan}
@@ -236,24 +237,25 @@ export default function SingleDayMealPlanPage() {
                 </button>
               </div>
             )}
-          </div>
-          <h1 className="text-2xl font-bold mb-4 text-center">
+            </div>
+            <h1 className="text-2xl font-bold mb-4 text-center">
             Single Day Meal Plan
-          </h1>
-          <SingleDayPlan
-            meals={meals}
-            onRemoveItem={handleRemoveItem}
-            onUpdateItem={handleUpdateItem}
-            calorieGoal={calorieGoal}
-            macroPercents={macroPercents}
-          />
-          <button
-            onClick={handleSavePlan}
-            className="anime-btn mt-4 px-4 py-2 bg-green-600 text-white"
-          >
-            Save Plan
-          </button>
-          {saveStatus && <div className="mt-2 text-sm">{saveStatus}</div>}
+            </h1>
+            <SingleDayPlan
+              meals={meals}
+              onRemoveItem={handleRemoveItem}
+              onUpdateItem={handleUpdateItem}
+              calorieGoal={calorieGoal}
+              macroPercents={macroPercents}
+            />
+            <button
+              onClick={handleSavePlan}
+              className="anime-btn mt-4 px-4 py-2 bg-green-600 text-white"
+            >
+              Save Plan
+            </button>
+            {saveStatus && <div className="mt-2 text-sm">{saveStatus}</div>}
+          </div>
           <DragOverlay>
             {dragItem && (
               <div className="p-2 bg-white rounded shadow border-2 border-blue-500 opacity-90 text-xs inline-flex flex-col items-start">

--- a/src/app/shopping/page.js
+++ b/src/app/shopping/page.js
@@ -10,6 +10,8 @@ export default function ShoppingPage() {
   const [ingredients, setIngredients] = useState({});
   const [mealPlan, setMealPlan] = useState(null);
   const [days, setDays] = useState(1);
+  const [planList, setPlanList] = useState([]);
+  const [selectedPlan, setSelectedPlan] = useState("");
 
   useEffect(() => {
     const fetchIngredients = async () => {
@@ -33,6 +35,24 @@ export default function ShoppingPage() {
     };
     fetchPlan();
   }, [user]);
+
+  useEffect(() => {
+    const fetchPlans = async () => {
+      if (!user) return;
+      const snap = await getDocs(collection(db, "users", user.uid, "plans"));
+      setPlanList(snap.docs.map((d) => d.id));
+    };
+    fetchPlans();
+  }, [user]);
+
+  const handleLoadPlan = async (name) => {
+    if (!user || !name) return;
+    const snap = await getDoc(doc(db, "users", user.uid, "plans", name));
+    if (snap.exists()) {
+      const data = snap.data();
+      setMealPlan(data.meals || null);
+    }
+  };
 
   const totals = {};
   if (mealPlan) {
@@ -79,6 +99,29 @@ export default function ShoppingPage() {
             onChange={(e) => setDays(Math.max(1, Number(e.target.value)))}
           />
         </div>
+        {planList.length > 0 && (
+          <div className="mb-4 flex items-center gap-2">
+            <select
+              className="border px-2 py-1 flex-1"
+              value={selectedPlan}
+              onChange={(e) => setSelectedPlan(e.target.value)}
+            >
+              <option value="">Load plan...</option>
+              {planList.map((p) => (
+                <option key={p} value={p}>
+                  {p}
+                </option>
+              ))}
+            </select>
+            <button
+              type="button"
+              onClick={() => handleLoadPlan(selectedPlan)}
+              className="anime-btn px-2"
+            >
+              Load
+            </button>
+          </div>
+        )}
         {groceryList.length === 0 ? (
           <div className="text-center mb-4">No saved meal plan.</div>
         ) : (

--- a/src/app/shopping/page.js
+++ b/src/app/shopping/page.js
@@ -91,13 +91,18 @@ export default function ShoppingPage() {
         <h1 className="text-3xl font-bold mb-4 font-heading text-center">Shopping List</h1>
         <div className="mb-4 text-center">
           <label className="mr-2 font-semibold">Days:</label>
-          <input
-            type="number"
-            min={1}
-            className="border px-2 py-1 w-20 text-center"
-            value={days}
-            onChange={(e) => setDays(Math.max(1, Number(e.target.value)))}
-          />
+          <div className="inline-flex gap-1">
+            {Array.from({ length: 7 }, (_, i) => i + 1).map((n) => (
+              <button
+                key={n}
+                type="button"
+                onClick={() => setDays(n)}
+                className={`anime-btn px-2 py-1 text-sm ${days === n ? "bg-blue-600 text-white" : ""}`}
+              >
+                {n}
+              </button>
+            ))}
+          </div>
         </div>
         {planList.length > 0 && (
           <div className="mb-4 flex items-center gap-2">

--- a/src/app/shopping/page.js
+++ b/src/app/shopping/page.js
@@ -9,7 +9,7 @@ export default function ShoppingPage() {
   const { user } = useAuth();
   const [ingredients, setIngredients] = useState({});
   const [mealPlan, setMealPlan] = useState(null);
-  const [days, setDays] = useState(1);
+  const [days, setDays] = useState(7);
   const [planList, setPlanList] = useState([]);
   const [selectedPlan, setSelectedPlan] = useState("");
 

--- a/src/app/shopping/page.js
+++ b/src/app/shopping/page.js
@@ -91,7 +91,7 @@ export default function ShoppingPage() {
         <h1 className="text-3xl font-bold mb-4 font-heading text-center">Shopping List</h1>
         <div className="mb-4 text-center">
           <label className="mr-2 font-semibold">Days:</label>
-          <div className="inline-flex gap-1">
+          <div className="inline-flex flex-wrap justify-center gap-1">
             {Array.from({ length: 7 }, (_, i) => i + 1).map((n) => (
               <button
                 key={n}
@@ -105,7 +105,7 @@ export default function ShoppingPage() {
           </div>
         </div>
         {planList.length > 0 && (
-          <div className="mb-4 flex items-center gap-2">
+          <div className="mb-4 flex flex-wrap items-center gap-2">
             <select
               className="border px-2 py-1 flex-1"
               value={selectedPlan}

--- a/src/app/shopping/page.js
+++ b/src/app/shopping/page.js
@@ -91,18 +91,17 @@ export default function ShoppingPage() {
         <h1 className="text-3xl font-bold mb-4 font-heading text-center">Shopping List</h1>
         <div className="mb-4 text-center">
           <label className="mr-2 font-semibold">Days:</label>
-          <div className="inline-flex flex-wrap justify-center gap-1">
+          <select
+            className="border px-2 py-1"
+            value={days}
+            onChange={(e) => setDays(Number(e.target.value))}
+          >
             {Array.from({ length: 7 }, (_, i) => i + 1).map((n) => (
-              <button
-                key={n}
-                type="button"
-                onClick={() => setDays(n)}
-                className={`anime-btn px-2 py-1 text-sm ${days === n ? "bg-blue-600 text-white" : ""}`}
-              >
+              <option key={n} value={n}>
                 {n}
-              </button>
+              </option>
             ))}
-          </div>
+          </select>
         </div>
         {planList.length > 0 && (
           <div className="mb-4 flex flex-wrap items-center gap-2">


### PR DESCRIPTION
## Summary
- support user-specific macro percentages and named meal plans
- allow loading/deleting named plans

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f87a2eb00832b8203afc8b701e8ca