### PR TITLE
Improve mobile navigation

### DIFF
--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -20,13 +20,18 @@ export const metadata = {
   title: "Meal Prep App",
 };
 
+export const viewport = {
+  width: "device-width",
+  initialScale: 1,
+};
+
 export default function RootLayout({ children }) {
   return (
     <html lang="en" className={`${mochiy.variable} ${quicksand.variable}`}>
       <body>
         <AuthProvider>
           <HeaderBar />
-          <div className="flex">
+          <div className="flex flex-col md:flex-row">
             <NavSidebar />
             <div className="flex-1">
               <AuthGuard>{children}</AuthGuard>

--- a/src/components/HeaderBar.js
+++ b/src/components/HeaderBar.js
@@ -7,12 +7,12 @@ export default function HeaderBar() {
       className="sticky top-0 z-10 w-full border-b border-gray-100 shadow-sm"
       style={{ background: "var(--anime-card)" }}
     >
-      <div className="max-w-7xl mx-auto flex justify-between items-center px-6 py-3">
+      <div className="max-w-7xl mx-auto flex justify-between items-center px-4 md:px-6 py-3">
         <span className="font-extrabold text-lg text-gray-900 tracking-tight font-heading">
           Prep Thy Mealz
         </span>
         {/* Mobile navigation */}
-        <nav className="flex gap-4 text-sm md:hidden">
+        <nav className="flex gap-3 sm:gap-4 text-sm md:hidden">
           <Link href="/" className="hover:underline">
             Dashboard
           </Link>

--- a/src/components/HeaderBar.js
+++ b/src/components/HeaderBar.js
@@ -1,7 +1,13 @@
-"use client";
 import Link from "next/link";
 
 export default function HeaderBar() {
+  const links = [
+    { href: "/", label: "Dashboard" },
+    { href: "/calculator", label: "Calculator" },
+    { href: "/plan", label: "Meal Plan" },
+    { href: "/shopping", label: "Shopping" },
+  ];
+
   return (
     <header
       className="sticky top-0 z-10 w-full border-b border-gray-100 shadow-sm"
@@ -13,18 +19,11 @@ export default function HeaderBar() {
         </span>
         {/* Mobile navigation */}
         <nav className="flex gap-3 sm:gap-4 text-sm md:hidden">
-          <Link href="/" className="hover:underline">
-            Dashboard
-          </Link>
-          <Link href="/calculator" className="hover:underline">
-            Calculator
-          </Link>
-          <Link href="/plan" className="hover:underline">
-            Meal Plan
-          </Link>
-          <Link href="/shopping" className="hover:underline">
-            Shopping
-          </Link>
+          {links.map(({ href, label }) => (
+            <Link key={href} href={href} className="hover:underline">
+              {label}
+            </Link>
+          ))}
         </nav>
       </div>
     </header>

--- a/src/components/HeaderBar.js
+++ b/src/components/HeaderBar.js
@@ -1,14 +1,31 @@
 "use client";
+import Link from "next/link";
+
 export default function HeaderBar() {
   return (
     <header
       className="sticky top-0 z-10 w-full border-b border-gray-100 shadow-sm"
       style={{ background: "var(--anime-card)" }}
     >
-      <div className="max-w-7xl mx-auto flex justify-center items-center px-6 py-3">
+      <div className="max-w-7xl mx-auto flex justify-between items-center px-6 py-3">
         <span className="font-extrabold text-lg text-gray-900 tracking-tight font-heading">
           Prep Thy Mealz
         </span>
+        {/* Mobile navigation */}
+        <nav className="flex gap-4 text-sm md:hidden">
+          <Link href="/" className="hover:underline">
+            Dashboard
+          </Link>
+          <Link href="/calculator" className="hover:underline">
+            Calculator
+          </Link>
+          <Link href="/plan" className="hover:underline">
+            Meal Plan
+          </Link>
+          <Link href="/shopping" className="hover:underline">
+            Shopping
+          </Link>
+        </nav>
       </div>
     </header>
   );

--- a/src/components/NavSidebar.js
+++ b/src/components/NavSidebar.js
@@ -3,7 +3,7 @@ import Link from "next/link";
 
 export default function NavSidebar() {
   return (
-    <aside className="w-48 h-screen sticky top-0 border-r bg-gray-50 p-4 flex flex-col">
+    <aside className="hidden md:flex w-48 h-screen sticky top-0 border-r bg-gray-50 p-4 flex-col">
       <Link href="/" className="mb-2 hover:underline">
         Dashboard
       </Link>


### PR DESCRIPTION
## Summary
- update `HeaderBar` with mobile navigation links
- hide sidebar on smaller screens

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685000a323d4832b83f2cceabbcc9a2e