### PR TITLE
Improve drag-and-drop UX and dashboard

### DIFF
--- a/public/cooking.svg
+++ b/public/cooking.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 80" width="100" height="80">
+  <rect x="20" y="30" width="60" height="30" fill="#d45437" stroke="#000" stroke-width="2"/>
+  <rect x="15" y="25" width="70" height="10" fill="#aaa" stroke="#000" stroke-width="2"/>
+  <line x1="35" y1="15" x2="35" y2="5" stroke="#666" stroke-width="2"/>
+  <line x1="50" y1="15" x2="50" y2="2" stroke="#666" stroke-width="2"/>
+  <line x1="65" y1="15" x2="65" y2="5" stroke="#666" stroke-width="2"/>
+</svg>

--- a/src/app/plan/page.js
+++ b/src/app/plan/page.js
@@ -103,25 +103,46 @@ export default function SingleDayMealPlanPage() {
   const handleDragEnd = (event) => {
     setDragItem(null);
     if (!event.over) return;
-    const meal = event.over.id.replace("SingleDay-", "");
+    const overId = event.over.id;
     const data = event.active.data.current;
-    setMeals((prev) => {
-      const updated = { ...prev };
-      const already = updated[meal].find(
-        (i) => i.id === data.id && i.type === data.type
-      );
-      if (already) return prev;
 
-      let newItem = { ...data };
-      if (newItem.type === "ingredient") {
-        if (newItem.servingSize) {
-          newItem.grams = newItem.servingSize;
-        }
+    if (overId === "Sidebar-ingredients" || overId === "Sidebar-recipes") {
+      if (data.source === "plan") {
+        setMeals((prev) => {
+          const updated = { ...prev };
+          updated[data.fromMeal].splice(data.index, 1);
+          return updated;
+        });
       }
+      return;
+    }
 
-      updated[meal] = [...updated[meal], newItem];
-      return updated;
-    });
+    if (overId.startsWith("SingleDay-")) {
+      const meal = overId.replace("SingleDay-", "");
+      if (data.source === "plan") {
+        setMeals((prev) => {
+          const updated = { ...prev };
+          const item = { ...data };
+          updated[data.fromMeal].splice(data.index, 1);
+          updated[meal] = [...updated[meal], item];
+          return updated;
+        });
+      } else {
+        setMeals((prev) => {
+          const updated = { ...prev };
+          const already = updated[meal].find(
+            (i) => i.id === data.id && i.type === data.type
+          );
+          if (already) return prev;
+          let newItem = { ...data };
+          if (newItem.type === "ingredient" && newItem.servingSize) {
+            newItem.grams = newItem.servingSize;
+          }
+          updated[meal] = [...updated[meal], newItem];
+          return updated;
+        });
+      }
+    }
   };
 
   const handleUpdateItem = (meal, idx, fields) => {

--- a/src/components/DashboardContent.js
+++ b/src/components/DashboardContent.js
@@ -1,5 +1,5 @@
 "use client";
-import Link from "next/link";
+import Image from "next/image";
 import { useAuth } from "@/components/auth/AuthContext";
 import { signOut } from "firebase/auth";
 import { auth } from "@/lib/firebase";
@@ -12,47 +12,29 @@ export default function DashboardContent() {
       className="flex flex-col items-center justify-center min-h-screen p-8"
       style={{ background: "var(--anime-bg)" }}
     >
-      <div className="w-full max-w-lg anime-card">
-        <div className="flex items-center justify-between mb-8">
-          <span className="text-lg">
-            🍳 Hello,{" "}
-            <span className="font-semibold">
-              {user?.displayName || user?.email}
-            </span>
-          </span>
-          <button
-            onClick={() => signOut(auth)}
-            className="anime-btn"
-            style={{ padding: "0.5rem 1rem", fontSize: "1rem" }}
-          >
-            Sign Out
-          </button>
-        </div>
-        <h1
-          className="text-3xl font-bold mb-8 font-heading"
-          style={{ color: "#d45437" }}
-        >
-          What would you like to do?
+      <div className="w-full max-w-lg anime-card text-center space-y-4">
+        <h1 className="text-3xl font-bold" style={{ color: "#d45437" }}>
+          Welcome to Meal Prep!
         </h1>
-        <div className="flex flex-col gap-6">
-          <Link href="/calculator" className="anime-btn text-xl text-center">
-            🔥 BMR/TDEE Calculator
-          </Link>
-          <Link
-            href="/plan"
-            className="anime-btn text-xl text-center"
-            style={{ background: "var(--anime-accent)" }}
-          >
-            🍙 Meal Plan
-          </Link>
-          <Link
-            href="/shopping"
-            className="anime-btn text-xl text-center"
-            style={{ background: "var(--anime-green)" }}
-          >
-            🛒 Shopping List
-          </Link>
-        </div>
+        <p>
+          Use the menu on the left to explore the app. Build recipes and meal
+          plans by dragging ingredients and recipes into your daily meals. You
+          can drag items between meals or back to the sidebar to remove them.
+        </p>
+        <Image
+          src="/cooking.svg"
+          alt="Cooking"
+          width={200}
+          height={160}
+          className="mx-auto"
+        />
+        <button
+          onClick={() => signOut(auth)}
+          className="anime-btn mt-4"
+          style={{ padding: "0.5rem 1rem", fontSize: "1rem" }}
+        >
+          Sign Out
+        </button>
       </div>
     </main>
   );

--- a/src/components/MealItemCard.js
+++ b/src/components/MealItemCard.js
@@ -1,4 +1,5 @@
 "use client";
+import { useDraggable } from "@dnd-kit/core";
 function getIngredientNutrition(item) {
   if (item.caloriesPerServing === undefined) return null;
   const factor = item.grams ? item.grams / (item.servingSize || 1) : 1;
@@ -22,7 +23,11 @@ function getRecipeNutrition(item) {
     : null;
 }
 
-export default function MealItemCard({ item, onRemove, onUpdate }) {
+export default function MealItemCard({ item, meal, index, onRemove, onUpdate }) {
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
+    id: `plan-${meal}-${index}`,
+    data: { ...item, fromMeal: meal, index, source: "plan" },
+  });
   const nutrition =
     item.type === "ingredient"
       ? getIngredientNutrition(item)
@@ -30,18 +35,23 @@ export default function MealItemCard({ item, onRemove, onUpdate }) {
 
   return (
     <div
+      ref={setNodeRef}
+      {...attributes}
+      {...listeners}
       className={`
-        bg-gray-100 
+        bg-gray-100
         inline-flex flex-col items-start text-xs
         px-2 py-1
         rounded
         shadow-sm
         whitespace-nowrap
+        ${isDragging ? "opacity-60" : ""}
       `}
       style={{
         minHeight: "28px",
         fontWeight: item.type === "recipe" ? "500" : "400",
         maxWidth: "220px",
+        cursor: "grab",
       }}
     >
       <div className="flex items-center gap-x-1 whitespace-nowrap">

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -1,17 +1,34 @@
 "use client";
 import SidebarItem from "./SidebarItem";
+import { useDroppable } from "@dnd-kit/core";
 
 export default function Sidebar({ ingredients, recipes }) {
+  const {
+    setNodeRef: recipesRef,
+    isOver: overRecipes,
+  } = useDroppable({ id: "Sidebar-recipes" });
+  const {
+    setNodeRef: ingRef,
+    isOver: overIngredients,
+  } = useDroppable({ id: "Sidebar-ingredients" });
+
   return (
     <aside className="md:w-[340px] w-full md:border-l border-t md:border-t-0 flex flex-col sticky top-0 right-0 h-screen bg-gray-50 z-10">
       <div className="flex flex-col h-full">
-        <div className="overflow-y-auto border-b p-2" style={{ height: "33%" }}>
+        <div
+          ref={recipesRef}
+          className={`overflow-y-auto border-b p-2 ${overRecipes ? "bg-blue-50" : ""}`}
+          style={{ height: "33%" }}
+        >
           <h2 className="font-bold mb-2 text-xs">Recipes</h2>
           {recipes.map((item) => (
             <SidebarItem key={item.id} item={item} type="recipe" />
           ))}
         </div>
-        <div className="overflow-y-auto p-2 flex-1">
+        <div
+          ref={ingRef}
+          className={`overflow-y-auto p-2 flex-1 ${overIngredients ? "bg-blue-50" : ""}`}
+        >
           <h2 className="font-bold mb-2 text-xs">Ingredients</h2>
           {ingredients.map((item) => (
             <SidebarItem key={item.id} item={item} type="ingredient" />

--- a/src/components/SingleMealDropCell.js
+++ b/src/components/SingleMealDropCell.js
@@ -18,6 +18,8 @@ export default function SingleMealDropCell({ meal, items, onRemoveItem, onUpdate
           <MealItemCard
             key={i.id + idx}
             item={i}
+            meal={meal}
+            index={idx}
             onRemove={() => onRemoveItem(meal, idx)}
             onUpdate={(fields) => onUpdateItem(meal, idx, fields)}
           />


### PR DESCRIPTION
## Summary
- enable dragging meal items between meal cells and back to sidebar
- add drag handles to meal item cards
- make sidebar drop targets for removing items
- simplify dashboard with explanation and cooking image

## Testing
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68501ac11ab8832bafbe749a38397bfe